### PR TITLE
chore: improve error handling in VTL templates

### DIFF
--- a/mapping-templates/Mutation.editMyProfile.response.vtl
+++ b/mapping-templates/Mutation.editMyProfile.response.vtl
@@ -1,1 +1,5 @@
+#if($context.error)
+$util.error($context.error.message, $context.error.type)
+#else
 $util.toJson($context.result)
+#end

--- a/mapping-templates/Mutation.notifyLiked.response.vtl
+++ b/mapping-templates/Mutation.notifyLiked.response.vtl
@@ -1,1 +1,5 @@
+#if($context.error)
+$util.error($context.error.message, $context.error.type)
+#else
 $util.toJson($context.result)
+#end

--- a/mapping-templates/Mutation.notifyMentioned.response.vtl
+++ b/mapping-templates/Mutation.notifyMentioned.response.vtl
@@ -1,1 +1,5 @@
+#if($context.error)
+$util.error($context.error.message, $context.error.type)
+#else
 $util.toJson($context.result)
+#end

--- a/mapping-templates/Mutation.notifyReplied.response.vtl
+++ b/mapping-templates/Mutation.notifyReplied.response.vtl
@@ -1,1 +1,5 @@
+#if($context.error)
+$util.error($context.error.message, $context.error.type)
+#else
 $util.toJson($context.result)
+#end

--- a/mapping-templates/Mutation.notifyRetweeted.response.vtl
+++ b/mapping-templates/Mutation.notifyRetweeted.response.vtl
@@ -1,1 +1,5 @@
+#if($context.error)
+$util.error($context.error.message, $context.error.type)
+#else
 $util.toJson($context.result)
+#end

--- a/mapping-templates/Query.getMyProfile.response.vtl
+++ b/mapping-templates/Query.getMyProfile.response.vtl
@@ -1,1 +1,5 @@
+#if($context.error)
+$util.error($context.error.message, $context.error.type)
+#else
 $util.toJson($context.result)
+#end

--- a/mapping-templates/Reply.inReplyToTweet.response.vtl
+++ b/mapping-templates/Reply.inReplyToTweet.response.vtl
@@ -1,1 +1,5 @@
+#if($context.error)
+$util.error($context.error.message, $context.error.type)
+#else
 $util.toJson($context.result)
+#end

--- a/mapping-templates/Retweet.retweetOf.response.vtl
+++ b/mapping-templates/Retweet.retweetOf.response.vtl
@@ -1,1 +1,5 @@
+#if($context.error)
+$util.error($context.error.message, $context.error.type)
+#else
 $util.toJson($context.result)
+#end

--- a/mapping-templates/Subscription.onNotified.response.vtl
+++ b/mapping-templates/Subscription.onNotified.response.vtl
@@ -1,1 +1,5 @@
+#if($context.error)
+$util.error($context.error.message, $context.error.type)
+#else
 $util.toJson($context.result)
+#end

--- a/mapping-templates/simplePipeline.response.vtl
+++ b/mapping-templates/simplePipeline.response.vtl
@@ -1,1 +1,5 @@
+#if($context.error)
+$util.error($context.error.message, $context.error.type)
+#else
 $util.toJson($context.result)
+#end


### PR DESCRIPTION
This PR will add error handling logic to a couple of VTL response templates. By adding additional logic internal are hidden by just throwing the message and its type to the client.

Background: 
I have been learning VTL templates and have noticed that most examples make us of a similar approach.
Instead of raising bugs, I have created a PR with these additions. If PR does not make sense or those changes are not aligned with the roadmap I will decline it.

Also, I think that couple of lambdas is missing `try-catch/catch` clauses around DocumentClient invocations.
For example `functions/unretweet.js` function, uses internal data checking and after that, it throws an error. Should we use try-catch here for better readability and move those checks to VTL templates and just throw errors?
